### PR TITLE
Fix https protocol setting

### DIFF
--- a/blazingdb/__init__.py
+++ b/blazingdb/__init__.py
@@ -409,7 +409,7 @@ class BlazingPyConnector:
         self.username = username
         self.password = password
         self.database = database
-        self.protocol = 'http' if (kwargs.get('https', True) == True) else 'http'
+        self.protocol = 'https' if (kwargs.get('https', True) == True) else 'http'
         self.context = kwargs.get('context', '/')
         self.baseurl = self.protocol+'://'+self.host+':'+self.port+self.context
         print "Base URL: " + self.baseurl

--- a/test/blazingdb/__init__.py
+++ b/test/blazingdb/__init__.py
@@ -409,7 +409,7 @@ class BlazingPyConnector:
         self.username = username
         self.password = password
         self.database = database
-        self.protocol = 'http' if (kwargs.get('https', True) == True) else 'http'
+        self.protocol = 'https' if (kwargs.get('https', True) == True) else 'http'
         self.context = kwargs.get('context', '/')
         self.baseurl = self.protocol+'://'+self.host+':'+self.port+self.context
         print "Base URL: " + self.baseurl


### PR DESCRIPTION
Hey,
I just noticed the protocol was being set to 'http' when asking for 'https' in the BlazingPyConnector.